### PR TITLE
Fix issue in the basic properties section.

### DIFF
--- a/docs/basic-properties.md
+++ b/docs/basic-properties.md
@@ -82,7 +82,7 @@ increase the height.
 
 ## Font Size Multiplier
 
-The `heightMultiplier` parameter sets the relative text size within the popup body.
+The `fontSizeMultiplier` parameter sets the relative text size within the popup body.
 
 | Name                 | Type    | Default Value |
 | -------------------- | ------- | ------------- |


### PR DESCRIPTION
The text incorrectly used heightMultiplier, rather than fontSizeMultiplier for the section about fontSizeMultiplier.